### PR TITLE
Allow double click on tool

### DIFF
--- a/extensions/cornerstone/src/initDoubleClick.ts
+++ b/extensions/cornerstone/src/initDoubleClick.ts
@@ -38,11 +38,11 @@ function initDoubleClick({
   commandsManager,
 }: initDoubleClickArgs): void {
   const cornerstoneViewportHandleDoubleClick = (evt: CustomEvent) => {
-    // Do not allow double click on a tool.
-    const nearbyToolData = findNearbyToolData(commandsManager, evt);
-    if (nearbyToolData) {
-      return;
-    }
+    // allow double click on a tool.
+    // const nearbyToolData = findNearbyToolData(commandsManager, evt);
+    // if (nearbyToolData) {
+    //   return;
+    // }
 
     const eventName = getDoubleClickEventName(evt);
 


### PR DESCRIPTION
Currently when the user is in a sagittal or coronal viewport and tries to double click to "focus" on a single viewport, when there is a measurement, ANYWHERE in the stack of slices so that the cursor is pointing towards it, it is ignored